### PR TITLE
Fix default obj parent name issue

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2391,6 +2391,13 @@ class TypesTest(unittest.TestCase):
         except Exception as e:
             self.assertTrue(str(e).startswith(name))
 
+        schema = StructType([StructField('a', StructType([StructField('b', IntegerType())]))])
+        try:
+            _verify_type([["data"]], schema)
+            self.fail('Expected _verify_type() to throw so test can check exception message')
+        except Exception as e:
+            self.assertTrue(str(e).startswith("a.b:"))
+
     def test_verify_type_ok_nullable(self):
         obj = None
         for data_type in [IntegerType(), FloatType(), StringType(), StructType([])]:
@@ -2406,7 +2413,7 @@ class TypesTest(unittest.TestCase):
         import datetime
         import decimal
 
-        MyStructType = StructType([
+        schema = StructType([
             StructField('s', StringType(), nullable=False),
             StructField('i', IntegerType(), nullable=True)])
 
@@ -2501,26 +2508,26 @@ class TypesTest(unittest.TestCase):
              ValueError),
 
             # Struct
-            ({"s": "a", "i": 1}, MyStructType, None),
-            ({"s": "a", "i": None}, MyStructType, None),
-            ({"s": "a"}, MyStructType, None),
-            ({"s": "a", "f": 1.0}, MyStructType, None),     # Extra fields OK
-            ({"s": "a", "i": "1"}, MyStructType, TypeError),
-            (Row(s="a", i=1), MyStructType, None),
-            (Row(s="a", i=None), MyStructType, None),
-            (Row(s="a", i=1, f=1.0), MyStructType, None),   # Extra fields OK
-            (Row(s="a"), MyStructType, ValueError),     # Row can't have missing field
-            (Row(s="a", i="1"), MyStructType, TypeError),
-            (["a", 1], MyStructType, None),
-            (["a", None], MyStructType, None),
-            (["a"], MyStructType, ValueError),
-            (["a", "1"], MyStructType, TypeError),
-            (("a", 1), MyStructType, None),
-            (MyObj(s="a", i=1), MyStructType, None),
-            (MyObj(s="a", i=None), MyStructType, None),
-            (MyObj(s="a"), MyStructType, None),
-            (MyObj(s="a", i="1"), MyStructType, TypeError),
-            (MyObj(s=None, i="1"), MyStructType, ValueError),
+            ({"s": "a", "i": 1}, schema, None),
+            ({"s": "a", "i": None}, schema, None),
+            ({"s": "a"}, schema, None),
+            ({"s": "a", "f": 1.0}, schema, None),     # Extra fields OK
+            ({"s": "a", "i": "1"}, schema, TypeError),
+            (Row(s="a", i=1), schema, None),
+            (Row(s="a", i=None), schema, None),
+            (Row(s="a", i=1, f=1.0), schema, None),   # Extra fields OK
+            (Row(s="a"), schema, ValueError),     # Row can't have missing field
+            (Row(s="a", i="1"), schema, TypeError),
+            (["a", 1], schema, None),
+            (["a", None], schema, None),
+            (["a"], schema, ValueError),
+            (["a", "1"], schema, TypeError),
+            (("a", 1), schema, None),
+            (MyObj(s="a", i=1), schema, None),
+            (MyObj(s="a", i=None), schema, None),
+            (MyObj(s="a"), schema, None),
+            (MyObj(s="a", i="1"), schema, TypeError),
+            (MyObj(s=None, i="1"), schema, ValueError),
         ]
 
         for obj, data_type, exp in spec:


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to get rid of "obj" prefix when `name` is `None`.


## How was this patch tested?

Manually tested and checked via

```
sh run-tests --modules pyspark-sql --python-executable python2.7
```

Also, manually tested as below:

```
from pyspark.sql.types import *

schema = StructType([StructField("a", IntegerType())])
spark.createDataFrame([["a"]], schema)
...
TypeError: a: IntegerType can not accept object 'a' in type <type 'str'>


schema = IntegerType()
spark.createDataFrame(["a"], IntegerType())
...
TypeError: value: IntegerType can not accept object 'a' in type <type 'str'>


schema = StructType([StructField("a", ArrayType(IntegerType()))])
spark.createDataFrame(["a"], schema)
...
TypeError: StructType can not accept object 'a' in type <type 'str'>


schema = StructType([StructField("a", ArrayType(IntegerType()))])
spark.createDataFrame([["a"]], schema)
...
TypeError: a: ArrayType(IntegerType,true) can not accept object 'a' in type <type 'str'>


schema = StructType([StructField("a", ArrayType(IntegerType()))])
spark.createDataFrame([[["a"]]], schema)
...
TypeError: a[0]: IntegerType can not accept object 'a' in type <type 'str'>


schema = StructType([StructField("a", ArrayType(StructType([StructField("a", IntegerType())])))])
spark.createDataFrame([[["b"]]], schema)
...
TypeError: a[0]: StructType can not accept object 'b' in type <type 'str'>


schema = StructType([StructField("a", MapType(IntegerType(), IntegerType()))])
spark.createDataFrame([{"a": "1"}], schema)
...
TypeError: a: MapType(IntegerType,IntegerType,true) can not accept object '1' in type <type 'str'>


schema = StructType([StructField("a", MapType(IntegerType(), IntegerType()))])
spark.createDataFrame([[{"1": "aa"}]], schema)
...
TypeError: a[1](key): IntegerType can not accept object '1' in type <type 'str'>


schema = StructType([StructField("a", MapType(IntegerType(), IntegerType()))])
spark.createDataFrame([[{1: "aa"}]], schema)
...
TypeError: a[1]: IntegerType can not accept object 'aa' in type <type 'str'>


schema = StructType([StructField("a", MapType(IntegerType(), StructType([StructField("a", IntegerType())])))])
spark.createDataFrame([[{1: ["1"]}]], schema)
...
TypeError: a[1].a: IntegerType can not accept object '1' in type <type 'str'>


schema = StructType([StructField("a", StructType([StructField("b", IntegerType())]))])
spark.createDataFrame([[["1"]]], schema)
...
TypeError: a.b: IntegerType can not accept object '1' in type <type 'str'>

schema = StructType([StructField("a", StructType([StructField("b", StructType([StructField("c", IntegerType())]))]))])
spark.createDataFrame([[[["1"]]]], schema)
...
TypeError: a.b.c: IntegerType can not accept object '1' in type <type 'str'>


schema = StructType([StructField("a", StructType([StructField("b", StructType([StructField("c", StructType([StructField("b", IntegerType())]))]))]))])
spark.createDataFrame([[[[["1"]]]]], schema)
...
TypeError: a.b.c.b: IntegerType can not accept object '1' in type <type 'str'>
```

